### PR TITLE
🐛Fix: Ajustar a exibição de Minhas Reservas

### DIFF
--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Views/Home/Index.cshtml
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Views/Home/Index.cshtml
@@ -184,11 +184,250 @@ else if (TempData["mensagemErro"] != null)
         $(document).ready(function () {
             if (document.querySelector('#mensagem-retorno'))
                 document.getElementById("mensagem-retorno").click();
+
+                 $(function() {
+            let codDia = new Date().getDay();
+            loadSalasByDiaSemana(getDiaSemana(codDia));
+            checkButtonByCodigoDia(codDia);
+        });
+
+        function submitForm(formId, idItem, salaParticular) {
+            if (salaParticular)
+                document.getElementById('tela-carregamento').hidden = false;
+            else
+                document.getElementById('tela-carregamento-reserva').hidden = false;
+
+            setValueSwitch(idItem);
+            if (document.querySelector('#' + formId))
+                document.getElementById(formId).submit();
+        }
+
+        function setValueSwitch(idMonitoramento) {
+            if ($('#luzes-' + idMonitoramento).is(":checked"))
+                $('#luzes-' + idMonitoramento).val(true);
+            else
+                $('#luzes-' + idMonitoramento).val(false);
+
+            if ($('#arCondicionado-' + idMonitoramento).is(":checked"))
+                $('#arCondicionado-' + idMonitoramento).val(true);
+            else
+                $('#arCondicionado-' + idMonitoramento).val(false);
+        }
+
+
+        function loadSalasByDiaSemana(dia) {
+            let url = "/Home/GetReservasUsuario";
+
+            checkButtonByCodigoDia(getCodigoSemana(dia));
+            document.getElementById('container-reservas').innerHTML = "";
+            $.get(url, { diaSemana: dia }, function (data) {
+                console.log("Dados recebidos da API:", data);
+                if (data.salasUsuario.length > 0) {
+                    for (var indice = 0; indice < data.salasUsuario.length; indice++)
+                        addReserva(data.salasUsuario[indice], indice, dia);
+                } else $('#container-reservas').append('<p class="text-center"> Não há nenhuma reserva para este dia nessa semana! </p>');
+            });
+        }
+
+        function addReserva(data, indice, dia) {
+            console.log("Dados da reserva:", data);
+            console.log("Data da reserva:", data.horarioSala.data);
+
+            // Format horários corretamente
+            let horarioInicio = formatarHorario(data.horarioSala.horarioInicio);
+            let horarioFim = formatarHorario(data.horarioSala.horarioFim);
+
+            var item = '<div class="card">' +
+                '<div class="card-header card-title">' +
+                '<h5 class="align-element">' + data.bloco.titulo + '<br/>' + data.sala.titulo + '</h5>' +
+                '<div class="align-element float-right">' +
+                '<h5 class="text-right">' + getDiaSemanaCompleto(dia) + '<br />' + moment(data.horarioSala.data).format('DD/MM/YYYY') + '</h5>' +
+                '</div>' +
+                '</div>' +
+                '<div class="card-body">' +
+                '<div class="align-element">' +
+                '<h5 class="card-text">' + horarioInicio + ' às ' + horarioFim + '</h5>' +
+                '<form asp-controller="Home" asp-action="CancelarReserva" method="post" action="/Home/CancelarReserva">' +
+                '<input class="form-control" name="idReserva" value="' + data.horarioSala.id + '" hidden>' +
+                '<input type="submit" class="btn btn-danger" value="Cancelar" />' +
+                '</form>' +
+                '</div>' +
+                '<div class="float-right">' +
+                '<div class="float-right">' +
+                '<div class="align-element">' +
+                '<form method="post" action="/Home/MonitorarSala" asp-controller="Home" asp-action="MonitorarSala" id="form-' + indice + "-" + data.monitoramentoLuzes.id + "-" + data.horarioSala.id + '">' +
+                '<div class="form-control" hidden>' +
+                '<input class="form-control" name="SalaId" value="' + data.sala.id + '" />' +
+                '<input class="form-control" name="Id" value="' + data.monitoramentoLuzes.id + '" />' +
+                '<input class="form-control" name="EquipamentoId" value="' + data.monitoramentoLuzes.equipamentoId + '" />' +
+                '<input class="form-control" name="SalaParticular" value="False" />' +
+                '</div>' +
+
+                '<div class="align-element">' +
+                '<h5 class="card-text">Luzes</h5>' +
+                '<label class="switch" onchange="submitForm(\'form-' + indice + "-" + data.monitoramentoLuzes.id + "-" + data.horarioSala.id + '\',\'' + indice + "-" + data.monitoramentoLuzes.id + "-" + data.horarioSala.id + '\',false)">' +
+                '<input type="checkbox" name="Estado" id="luzes-' + indice + "-" + data.monitoramentoLuzes.id + "-" + data.horarioSala.id + '" value="' + data.monitoramentoLuzes.estado + '"' + new String(data.monitoramentoLuzes.estado ? "checked" : "") + '/>' +
+                '<span class="slider round"></span>' +
+                '</label>' +
+                '</div>' +
+                '</form>' +
+                '</div>' +
+                '</div>' +
+
+                '<div class="float-right">' +
+                '<div class="align-element">' +
+                '<form method="post" action="/Home/MonitorarSala" asp-controller="Home" asp-action="MonitorarSala" id="form-' + indice + "-" + data.monitoramentoCondicionadores.id + "-" + data.horarioSala.id + '">' +
+                '<div class="form-control" hidden>' +
+                '<input class="form-control" name="SalaId" value="' + data.sala.id + '" />' +
+                '<input class="form-control" name="Id" value="' + data.monitoramentoCondicionadores.id + '" />' +
+                '<input class="form-control" name="EquipamentoId" value="' + data.monitoramentoCondicionadores.equipamentoId + '" />' +
+                '<input class="form-control" name="SalaParticular" value="False" />' +
+                '</div>' +
+
+                '<div class="align-element">' +
+                '<h5 class="card-text">Condicionadores</h5>' +
+                '<label class="switch" onchange="submitForm(\'form-' + indice + "-" + data.monitoramentoCondicionadores.id + "-" + data.horarioSala.id + '\',\'' + indice + "-" + data.monitoramentoCondicionadores.id + "-" + data.horarioSala.id + '\',false)">' +
+                '<input type="checkbox" name="Estado" id="arCondicionado-' + indice + "-" + data.monitoramentoCondicionadores.id + "-" + data.horarioSala.id + '" value="' + data.monitoramentoCondicionadores.estado + '"' + new String(data.monitoramentoCondicionadores.estado ? "checked" : "") + '/>' +
+                '<span class="slider round"></span>' +
+                '</label>' +
+                '</div>' +
+                '</form>' +
+                '</div>' +
+                '</div>' +
+
+                '</div>'
+            '</div>' +
+                '</div>';
+
+            $('#container-reservas').append(item);
+        }
+
+        // Nova função para tratar os diferentes formatos possíveis de horários
+        function formatarHorario(horario) {
+            if (!horario) {
+                console.log("Horário indefinido");
+                return "00:00";
+            }
+
+            console.log("Tipo de horário:", typeof horario, horario);
+
+            // Se for um objeto com totalMilliseconds
+            if (typeof horario === 'object' && horario.totalMilliseconds !== undefined) {
+                return convertMsToHM(horario.totalMilliseconds);
+            }
+
+            // Se for uma string no formato "hh:mm:ss"
+            if (typeof horario === 'string') {
+                const partes = horario.split(':');
+                if (partes.length >= 2) {
+                    return padTo2Digits(parseInt(partes[0])) + ':' + padTo2Digits(parseInt(partes[1]));
+                }
+            }
+
+            // Se for um número (total de milissegundos)
+            if (typeof horario === 'number') {
+                return convertMsToHM(horario);
+            }
+
+            // Se for um objeto com horas e minutos
+            if (typeof horario === 'object' && horario.hours !== undefined && horario.minutes !== undefined) {
+                return padTo2Digits(horario.hours) + ':' + padTo2Digits(horario.minutes);
+            }
+
+            // Se ainda não conseguiu interpretar, retorna como está
+            return String(horario);
+        }
+
+        function padTo2Digits(num) {
+            return num.toString().padStart(2, '0');
+        }
+
+        function convertMsToHM(milliseconds) {
+            if (milliseconds === undefined) {
+                console.log("Milissegundos indefinidos");
+                return "00:00";
+            }
+
+            let seconds = Math.floor(milliseconds / 1000);
+            let minutes = Math.floor(seconds / 60);
+            let hours = Math.floor(minutes / 60);
+
+            seconds = seconds % 60;
+            minutes = seconds >= 30 ? minutes + 1 : minutes;
+
+            minutes = minutes % 60;
+
+            hours = hours % 24;
+
+            return `${padTo2Digits(hours)}:${padTo2Digits(minutes)}`;
+        }
+
+        function checkButtonByCodigoDia(dia) {
+            switch (dia) {
+                case 0: document.getElementById("option_dom").checked = true;
+                    break;
+                case 1: document.getElementById("option_seg").checked = true;
+                    break;
+                case 2: document.getElementById("option_ter").checked = true; // Corrigi de enable para checked
+                    break;
+                case 3: document.getElementById("option_qua").checked = true;
+                    break;
+                case 4: document.getElementById("option_qui").checked = true;
+                    break;
+                case 5: document.getElementById("option_sex").checked = true;
+                    break;
+                case 6: document.getElementById("option_sab").checked = true;
+                    break;
+                default: return "";
+            }
+        }
+
+        function getDiaSemana(codigoDia) {
+            switch (codigoDia) {
+                case 0: return "DOM";
+                case 1: return "SEG";
+                case 2: return "TER";
+                case 3: return "QUA";
+                case 4: return "QUI";
+                case 5: return "SEX";
+                case 6: return "SAB";
+                default: return "";
+            }
+        }
+
+        function getCodigoSemana(dia) {
+            switch (dia) {
+                case "DOM": return 0;
+                case "SEG": return 1;
+                case "TER": return 2;
+                case "QUA": return 3;
+                case "QUI": return 4;
+                case "SEX": return 5;
+                case "SAB": return 6;
+                default: return 0;
+            }
+        }
+
+        function getDiaSemanaCompleto(dia) {
+            if (getDiaSemana(new Date().getDay()) == dia)
+                return "Hoje";
+
+            switch (dia) {
+                case "DOM": return "Próximo Domingo";
+                case "SEG": return "Próxima Segunda-Feira";
+                case "TER": return "Próxima Terça-Feira";
+                case "QUA": return "Próxima Quarta-Feira";
+                case "QUI": return "Próxima Quinta-Feira";
+                case "SEX": return "Próxima Sexta-Feira";
+                case "SAB": return "Próximo Sábado";
+                default: return "";
+            }
+        }
         });
     </script>
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@9"></script>
     <script src="~/js/sweet-alert.js"></script>
     <script type="text/javascript" src="~/js/moment.js"></script>
-    <script type="text/javascript" src="~/js/dashboard-script.js"></script>
+    
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
 }

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Views/Home/Index.cshtml
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Views/Home/Index.cshtml
@@ -184,8 +184,9 @@ else if (TempData["mensagemErro"] != null)
         $(document).ready(function () {
             if (document.querySelector('#mensagem-retorno'))
                 document.getElementById("mensagem-retorno").click();
+        });
 
-                 $(function() {
+                $(function() {
             let codDia = new Date().getDay();
             loadSalasByDiaSemana(getDiaSemana(codDia));
             checkButtonByCodigoDia(codDia);
@@ -423,11 +424,9 @@ else if (TempData["mensagemErro"] != null)
                 default: return "";
             }
         }
-        });
     </script>
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@9"></script>
     <script src="~/js/sweet-alert.js"></script>
     <script type="text/javascript" src="~/js/moment.js"></script>
-    
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
 }

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/wwwroot/js/dashboard-script.js
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/wwwroot/js/dashboard-script.js
@@ -1,4 +1,4 @@
-﻿$(document).ready(function () {
+﻿$(function() {
     let codDia = new Date().getDay();
     loadSalasByDiaSemana(getDiaSemana(codDia));
     checkButtonByCodigoDia(codDia);
@@ -11,7 +11,7 @@ function submitForm(formId, idItem, salaParticular) {
         document.getElementById('tela-carregamento-reserva').hidden = false;
 
     setValueSwitch(idItem);
-    if (document.querySelector('#'+formId))
+    if (document.querySelector('#' + formId))
         document.getElementById(formId).submit();
 }
 
@@ -42,16 +42,19 @@ function loadSalasByDiaSemana(dia) {
     });
 }
 
-function addReserva(data, indice, dia) {  
+function addReserva(data, indice, dia) {
+    console.log("Dados da reserva:", data);
+    console.log("Data da reserva:", data.horarioSala.data);
+
     // Format horários corretamente
     let horarioInicio = formatarHorario(data.horarioSala.horarioInicio);
     let horarioFim = formatarHorario(data.horarioSala.horarioFim);
-    
+
     var item = '<div class="card">' +
         '<div class="card-header card-title">' +
         '<h5 class="align-element">' + data.bloco.titulo + '<br/>' + data.sala.titulo + '</h5>' +
         '<div class="align-element float-right">' +
-        '<h5 class="text-right">' + getDiaSemanaCompleto(dia) + '<br />' + moment(data.horarioSala.data).format('DD/MM/YYYY')+'</h5>'+
+        '<h5 class="text-right">' + getDiaSemanaCompleto(dia) + '<br />' + moment(data.horarioSala.data).format('DD/MM/YYYY') + '</h5>' +
         '</div>' +
         '</div>' +
         '<div class="card-body">' +
@@ -63,50 +66,50 @@ function addReserva(data, indice, dia) {
         '</form>' +
         '</div>' +
         '<div class="float-right">' +
-            '<div class="float-right">' + 
-                '<div class="align-element">' +   
-                    '<form method="post" action="/Home/MonitorarSala" asp-controller="Home" asp-action="MonitorarSala" id="form-' + indice + "-" + data.monitoramentoLuzes.id + "-" + data.horarioSala.id + '">' +
-                        '<div class="form-control" hidden>' +
-                            '<input class="form-control" name="SalaId" value="' + data.sala.id + '" />' +
-                            '<input class="form-control" name="Id" value="' + data.monitoramentoLuzes.id + '" />' +
-                            '<input class="form-control" name="EquipamentoId" value="' + data.monitoramentoLuzes.equipamentoId +'" />' +
-                            '<input class="form-control" name="SalaParticular" value="False" />' +
-                        '</div>' +
+        '<div class="float-right">' +
+        '<div class="align-element">' +
+        '<form method="post" action="/Home/MonitorarSala" asp-controller="Home" asp-action="MonitorarSala" id="form-' + indice + "-" + data.monitoramentoLuzes.id + "-" + data.horarioSala.id + '">' +
+        '<div class="form-control" hidden>' +
+        '<input class="form-control" name="SalaId" value="' + data.sala.id + '" />' +
+        '<input class="form-control" name="Id" value="' + data.monitoramentoLuzes.id + '" />' +
+        '<input class="form-control" name="EquipamentoId" value="' + data.monitoramentoLuzes.equipamentoId + '" />' +
+        '<input class="form-control" name="SalaParticular" value="False" />' +
+        '</div>' +
 
-                         '<div class="align-element">' +
-                             '<h5 class="card-text">Luzes</h5>' +
-                                    '<label class="switch" onchange="submitForm(\'form-' + indice + "-" + data.monitoramentoLuzes.id + "-" + data.horarioSala.id + '\',\'' + indice + "-" + data.monitoramentoLuzes.id + "-" + data.horarioSala.id + '\',false)">' +
-                                    '<input type="checkbox" name="Estado" id="luzes-' + indice + "-" + data.monitoramentoLuzes.id + "-" + data.horarioSala.id + '" value="' + data.monitoramentoLuzes.estado + '"' + new String(data.monitoramentoLuzes.estado ? "checked" : "") + '/>' +
-                                    '<span class="slider round"></span>' +
-                             '</label>' +
-                        '</div>' +
-                      '</form>' +
-                '</div>' +
-            '</div>' +
+        '<div class="align-element">' +
+        '<h5 class="card-text">Luzes</h5>' +
+        '<label class="switch" onchange="submitForm(\'form-' + indice + "-" + data.monitoramentoLuzes.id + "-" + data.horarioSala.id + '\',\'' + indice + "-" + data.monitoramentoLuzes.id + "-" + data.horarioSala.id + '\',false)">' +
+        '<input type="checkbox" name="Estado" id="luzes-' + indice + "-" + data.monitoramentoLuzes.id + "-" + data.horarioSala.id + '" value="' + data.monitoramentoLuzes.estado + '"' + new String(data.monitoramentoLuzes.estado ? "checked" : "") + '/>' +
+        '<span class="slider round"></span>' +
+        '</label>' +
+        '</div>' +
+        '</form>' +
+        '</div>' +
+        '</div>' +
 
-            '<div class="float-right">' + 
-                '<div class="align-element">' +    
-                    '<form method="post" action="/Home/MonitorarSala" asp-controller="Home" asp-action="MonitorarSala" id="form-' + indice + "-" + data.monitoramentoCondicionadores.id + "-" + data.horarioSala.id + '">' +
-                        '<div class="form-control" hidden>' +
-                            '<input class="form-control" name="SalaId" value="' + data.sala.id + '" />' +
-                            '<input class="form-control" name="Id" value="' + data.monitoramentoCondicionadores.id + '" />' +
-                            '<input class="form-control" name="EquipamentoId" value="' + data.monitoramentoCondicionadores.equipamentoId + '" />' +
-                            '<input class="form-control" name="SalaParticular" value="False" />' +
-                        '</div>' +
+        '<div class="float-right">' +
+        '<div class="align-element">' +
+        '<form method="post" action="/Home/MonitorarSala" asp-controller="Home" asp-action="MonitorarSala" id="form-' + indice + "-" + data.monitoramentoCondicionadores.id + "-" + data.horarioSala.id + '">' +
+        '<div class="form-control" hidden>' +
+        '<input class="form-control" name="SalaId" value="' + data.sala.id + '" />' +
+        '<input class="form-control" name="Id" value="' + data.monitoramentoCondicionadores.id + '" />' +
+        '<input class="form-control" name="EquipamentoId" value="' + data.monitoramentoCondicionadores.equipamentoId + '" />' +
+        '<input class="form-control" name="SalaParticular" value="False" />' +
+        '</div>' +
 
-                        '<div class="align-element">' +
-                                '<h5 class="card-text">Condicionadores</h5>' +
-                                '<label class="switch" onchange="submitForm(\'form-' + indice + "-" + data.monitoramentoCondicionadores.id + "-" + data.horarioSala.id + '\',\'' + indice + "-" + data.monitoramentoCondicionadores.id + "-" + data.horarioSala.id + '\',false)">' +
-                                '<input type="checkbox" name="Estado" id="arCondicionado-' + indice + "-" + data.monitoramentoCondicionadores.id + "-" + data.horarioSala.id + '" value="' + data.monitoramentoCondicionadores.estado + '"' + new String(data.monitoramentoCondicionadores.estado ? "checked" : "") +'/>' +
-                                '<span class="slider round"></span>' +
-                                '</label>' +
-                        '</div>' +
-                    '</form>' +
-                '</div>' +
-            '</div>' +
+        '<div class="align-element">' +
+        '<h5 class="card-text">Condicionadores</h5>' +
+        '<label class="switch" onchange="submitForm(\'form-' + indice + "-" + data.monitoramentoCondicionadores.id + "-" + data.horarioSala.id + '\',\'' + indice + "-" + data.monitoramentoCondicionadores.id + "-" + data.horarioSala.id + '\',false)">' +
+        '<input type="checkbox" name="Estado" id="arCondicionado-' + indice + "-" + data.monitoramentoCondicionadores.id + "-" + data.horarioSala.id + '" value="' + data.monitoramentoCondicionadores.estado + '"' + new String(data.monitoramentoCondicionadores.estado ? "checked" : "") + '/>' +
+        '<span class="slider round"></span>' +
+        '</label>' +
+        '</div>' +
+        '</form>' +
+        '</div>' +
+        '</div>' +
 
         '</div>'
-        '</div>' +
+    '</div>' +
         '</div>';
 
     $('#container-reservas').append(item);
@@ -118,14 +121,14 @@ function formatarHorario(horario) {
         console.log("Horário indefinido");
         return "00:00";
     }
-    
+
     console.log("Tipo de horário:", typeof horario, horario);
-    
+
     // Se for um objeto com totalMilliseconds
     if (typeof horario === 'object' && horario.totalMilliseconds !== undefined) {
         return convertMsToHM(horario.totalMilliseconds);
     }
-    
+
     // Se for uma string no formato "hh:mm:ss"
     if (typeof horario === 'string') {
         const partes = horario.split(':');
@@ -133,17 +136,17 @@ function formatarHorario(horario) {
             return padTo2Digits(parseInt(partes[0])) + ':' + padTo2Digits(parseInt(partes[1]));
         }
     }
-    
+
     // Se for um número (total de milissegundos)
     if (typeof horario === 'number') {
         return convertMsToHM(horario);
     }
-    
+
     // Se for um objeto com horas e minutos
     if (typeof horario === 'object' && horario.hours !== undefined && horario.minutes !== undefined) {
         return padTo2Digits(horario.hours) + ':' + padTo2Digits(horario.minutes);
     }
-    
+
     // Se ainda não conseguiu interpretar, retorna como está
     return String(horario);
 }
@@ -157,7 +160,7 @@ function convertMsToHM(milliseconds) {
         console.log("Milissegundos indefinidos");
         return "00:00";
     }
-    
+
     let seconds = Math.floor(milliseconds / 1000);
     let minutes = Math.floor(seconds / 60);
     let hours = Math.floor(minutes / 60);


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/user-attachments/assets/04a51bd6-7788-4f06-a24b-9c8ebc5154e6" width="10%">
  <h2>Pull Request</h2> 
</div>


## Foi Solicitado
A area de minhas reservas possui algumas inconcistência, falta de exibição de horário e caso seja cadastrado um planejamento todas as reservas do dia tal serão mostradas de uma vez e não apenas o da semana corrente. Portanto e necessário ajustar.

## Foi Feito
- [x] Alterações na view
- [x] Alterações num método de horário
- [x] Alterações no arquivo JS.

## Como Testar
Faça uma reserva de sala na sala 01 do bloco A no dia de hoje, e verifique se mostra o horario agora.

## Prints
![image](https://github.com/user-attachments/assets/adf905a3-1d34-47db-b871-a7afcfeee296)



**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**
