### PR TITLE
Ajustar o funcionamento de cancelar reserva 

### DIFF
--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/Business/HorarioSalaService.cs
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/Business/HorarioSalaService.cs
@@ -193,8 +193,7 @@ namespace Service
 
             var reservas = _context.Horariosalas
                 .Where(hs => hs.IdUsuario == idUsuario &&
-                             hs.Data.Date == nextOccurrence.Date &&
-                             !hs.Situacao.Equals(HorarioSalaModel.SITUACAO_CANCELADA))
+                             hs.Data.Date == nextOccurrence.Date)
                 .Select(hs => new HorarioSalaModel
                 {
                     Id = hs.Id,
@@ -217,6 +216,21 @@ namespace Service
             {
                 var reserva = GetById(idReserva);
                 reserva.Situacao = HorarioSalaModel.SITUACAO_CANCELADA;
+
+                return Update(reserva);
+            }
+            catch (Exception e)
+            {
+                throw e;
+            }
+        }
+
+        public bool AprovarReserva(uint idReserva)
+        {
+            try
+            {
+                var reserva = GetById(idReserva);
+                reserva.Situacao = HorarioSalaModel.SITUACAO_APROVADA;  
 
                 return Update(reserva);
             }

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/Business/Interface/IHorarioSalaService.cs
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/Business/Interface/IHorarioSalaService.cs
@@ -23,6 +23,7 @@ namespace Service.Interface
         bool Remove(int id);
         bool RemoveByUsuario(uint id);
         bool ConcelarReserva(uint idReserva);
+        bool AprovarReserva(uint idReserva);
         bool Update(HorarioSalaModel entity);
     }
 }

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Controllers/HomeController.cs
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Controllers/HomeController.cs
@@ -76,6 +76,23 @@ namespace SalasWeb.Controllers
             return RedirectToAction(nameof(Index));
         }
 
+        public IActionResult AprovarReserva(uint idReserva)
+        {
+            try
+            {
+                if (_horarioSalaService.AprovarReserva(idReserva))
+                    TempData["mensagemSucesso"] = "Reserva aprovada com sucesso!";
+                else
+                    TempData["mensagemErro"] = "Houve um problema ao aprovar sua reserva, tente novamente em alguns minutos!";
+            }
+            catch (ServiceException se)
+            {
+                TempData["mensagemErro"] = se.Message;
+            }
+
+            return RedirectToAction(nameof(Index));
+        }
+
         public IActionResult Privacy()
         {
             return View();

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Views/Home/Index.cshtml
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Views/Home/Index.cshtml
@@ -231,7 +231,7 @@ else if (TempData["mensagemErro"] != null)
                 // Variável global para rastrear a última data mostrada
         var ultimaDataMostrada = null;
 
-        function addReserva(data, indice, dia) {
+                function addReserva(data, indice, dia) {
             console.log("Dados da reserva:", data);
             console.log("Data da reserva:", data.horarioSala.data);
 
@@ -254,6 +254,72 @@ else if (TempData["mensagemErro"] != null)
                 '<h5 class="text-right">' + moment(data.horarioSala.data).format('DD/MM/YYYY') + '</h5>' +
                 '</div>' : '';
 
+            // Verifica o status da reserva para determinar qual botão mostrar e se exibe os controles
+            let botaoReserva = '';
+            let mostrarControles = true;  // Flag para determinar se mostra os controles de equipamentos
+
+            if (data.horarioSala.situacao === 'CANCELADA') {
+                botaoReserva = '<form asp-controller="Home" asp-action="AprovarReserva" method="post" action="/Home/AprovarReserva">' +
+                    '<input class="form-control" name="idReserva" value="' + data.horarioSala.id + '" hidden>' +
+                    '<input type="submit" class="btn btn-primary" value="Aprovar" />' +
+                    '</form>';
+                mostrarControles = false;  // Não mostra controles se estiver cancelada
+            } else {
+                botaoReserva = '<form asp-controller="Home" asp-action="CancelarReserva" method="post" action="/Home/CancelarReserva">' +
+                    '<input class="form-control" name="idReserva" value="' + data.horarioSala.id + '" hidden>' +
+                    '<input type="submit" class="btn btn-danger" value="Cancelar" />' +
+                    '</form>';
+            }
+
+            // Container dos equipamentos (será preenchido apenas se mostrarControles for true)
+            let controlesEquipamentos = '';
+
+            if (mostrarControles) {
+                controlesEquipamentos =
+                    '<div class="float-right">' +
+                    '<div class="float-right">' +
+                    '<div class="align-element">' +
+                    '<form method="post" action="/Home/MonitorarSala" asp-controller="Home" asp-action="MonitorarSala" id="form-' + indice + "-" + data.monitoramentoLuzes.id + "-" + data.horarioSala.id + '">' +
+                    '<div class="form-control" hidden>' +
+                    '<input class="form-control" name="SalaId" value="' + data.sala.id + '" />' +
+                    '<input class="form-control" name="Id" value="' + data.monitoramentoLuzes.id + '" />' +
+                    '<input class="form-control" name="EquipamentoId" value="' + data.monitoramentoLuzes.equipamentoId + '" />' +
+                    '<input class="form-control" name="SalaParticular" value="False" />' +
+                    '</div>' +
+
+                    '<div class="align-element">' +
+                    '<h5 class="card-text">Luzes</h5>' +
+                    '<label class="switch" onchange="submitForm(\'form-' + indice + "-" + data.monitoramentoLuzes.id + "-" + data.horarioSala.id + '\',\'' + indice + "-" + data.monitoramentoLuzes.id + "-" + data.horarioSala.id + '\',false)">' +
+                    '<input type="checkbox" name="Estado" id="luzes-' + indice + "-" + data.monitoramentoLuzes.id + "-" + data.horarioSala.id + '" value="' + data.monitoramentoLuzes.estado + '"' + new String(data.monitoramentoLuzes.estado ? "checked" : "") + '/>' +
+                    '<span class="slider round"></span>' +
+                    '</label>' +
+                    '</div>' +
+                    '</form>' +
+                    '</div>' +
+                    '</div>' +
+
+                    '<div class="float-right">' +
+                    '<div class="align-element">' +
+                    '<form method="post" action="/Home/MonitorarSala" asp-controller="Home" asp-action="MonitorarSala" id="form-' + indice + "-" + data.monitoramentoCondicionadores.id + "-" + data.horarioSala.id + '">' +
+                    '<div class="form-control" hidden>' +
+                    '<input class="form-control" name="SalaId" value="' + data.sala.id + '" />' +
+                    '<input class="form-control" name="Id" value="' + data.monitoramentoCondicionadores.id + '" />' +
+                    '<input class="form-control" name="EquipamentoId" value="' + data.monitoramentoCondicionadores.equipamentoId + '" />' +
+                    '<input class="form-control" name="SalaParticular" value="False" />' +
+                    '</div>' +
+
+                    '<div class="align-element">' +
+                    '<h5 class="card-text">Condicionadores</h5>' +
+                    '<label class="switch" onchange="submitForm(\'form-' + indice + "-" + data.monitoramentoCondicionadores.id + "-" + data.horarioSala.id + '\',\'' + indice + "-" + data.monitoramentoCondicionadores.id + "-" + data.horarioSala.id + '\',false)">' +
+                    '<input type="checkbox" name="Estado" id="arCondicionado-' + indice + "-" + data.monitoramentoCondicionadores.id + "-" + data.horarioSala.id + '" value="' + data.monitoramentoCondicionadores.estado + '"' + new String(data.monitoramentoCondicionadores.estado ? "checked" : "") + '/>' +
+                    '<span class="slider round"></span>' +
+                    '</label>' +
+                    '</div>' +
+                    '</form>' +
+                    '</div>' +
+                    '</div>';
+            }
+
             var item = '<div class="card">' +
                 '<div class="card-header card-title" style="border-bottom: none; padding-bottom: 0.0rem;">' +
                 '<h5 class="align-element">' + data.bloco.titulo + ' - ' + data.sala.titulo + '</h5>' +
@@ -262,55 +328,9 @@ else if (TempData["mensagemErro"] != null)
                 '<div class="card-body" style="padding-top: 0.0rem;">' +
                 '<div class="align-element">' +
                 '<h5 class="card-text">' + horarioInicio + ' às ' + horarioFim + '</h5>' +
-                '<form asp-controller="Home" asp-action="CancelarReserva" method="post" action="/Home/CancelarReserva">' +
-                '<input class="form-control" name="idReserva" value="' + data.horarioSala.id + '" hidden>' +
-                '<input type="submit" class="btn btn-danger" value="Cancelar" />' +
-                '</form>' +
+                botaoReserva +
                 '</div>' +
-                '<div class="float-right">' +
-                '<div class="float-right">' +
-                '<div class="align-element">' +
-                '<form method="post" action="/Home/MonitorarSala" asp-controller="Home" asp-action="MonitorarSala" id="form-' + indice + "-" + data.monitoramentoLuzes.id + "-" + data.horarioSala.id + '">' +
-                '<div class="form-control" hidden>' +
-                '<input class="form-control" name="SalaId" value="' + data.sala.id + '" />' +
-                '<input class="form-control" name="Id" value="' + data.monitoramentoLuzes.id + '" />' +
-                '<input class="form-control" name="EquipamentoId" value="' + data.monitoramentoLuzes.equipamentoId + '" />' +
-                '<input class="form-control" name="SalaParticular" value="False" />' +
-                '</div>' +
-
-                '<div class="align-element">' +
-                '<h5 class="card-text">Luzes</h5>' +
-                '<label class="switch" onchange="submitForm(\'form-' + indice + "-" + data.monitoramentoLuzes.id + "-" + data.horarioSala.id + '\',\'' + indice + "-" + data.monitoramentoLuzes.id + "-" + data.horarioSala.id + '\',false)">' +
-                '<input type="checkbox" name="Estado" id="luzes-' + indice + "-" + data.monitoramentoLuzes.id + "-" + data.horarioSala.id + '" value="' + data.monitoramentoLuzes.estado + '"' + new String(data.monitoramentoLuzes.estado ? "checked" : "") + '/>' +
-                '<span class="slider round"></span>' +
-                '</label>' +
-                '</div>' +
-                '</form>' +
-                '</div>' +
-                '</div>' +
-
-                '<div class="float-right">' +
-                '<div class="align-element">' +
-                '<form method="post" action="/Home/MonitorarSala" asp-controller="Home" asp-action="MonitorarSala" id="form-' + indice + "-" + data.monitoramentoCondicionadores.id + "-" + data.horarioSala.id + '">' +
-                '<div class="form-control" hidden>' +
-                '<input class="form-control" name="SalaId" value="' + data.sala.id + '" />' +
-                '<input class="form-control" name="Id" value="' + data.monitoramentoCondicionadores.id + '" />' +
-                '<input class="form-control" name="EquipamentoId" value="' + data.monitoramentoCondicionadores.equipamentoId + '" />' +
-                '<input class="form-control" name="SalaParticular" value="False" />' +
-                '</div>' +
-
-                '<div class="align-element">' +
-                '<h5 class="card-text">Condicionadores</h5>' +
-                '<label class="switch" onchange="submitForm(\'form-' + indice + "-" + data.monitoramentoCondicionadores.id + "-" + data.horarioSala.id + '\',\'' + indice + "-" + data.monitoramentoCondicionadores.id + "-" + data.horarioSala.id + '\',false)">' +
-                '<input type="checkbox" name="Estado" id="arCondicionado-' + indice + "-" + data.monitoramentoCondicionadores.id + "-" + data.horarioSala.id + '" value="' + data.monitoramentoCondicionadores.estado + '"' + new String(data.monitoramentoCondicionadores.estado ? "checked" : "") + '/>' +
-                '<span class="slider round"></span>' +
-                '</label>' +
-                '</div>' +
-                '</form>' +
-                '</div>' +
-                '</div>' +
-
-                '</div>'+
+                controlesEquipamentos +
                 '</div>' +
                 '</div>';
 


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/user-attachments/assets/04a51bd6-7788-4f06-a24b-9c8ebc5154e6" width="10%">
  <h2>Pull Request</h2> 
</div>


## Foi Solicitado
Atualmente ao clicar em cancelar a reserva, basicamente a reserva é cancelada. O funcionamento correto deve ser ao clicar em cancelar muda o staus para cancelado, porém a reserva continua sendo do usuário, podendo ter a opção de retomar reserva, a opção de cancelar serve apenas para que o gestor saiba que o colobador no momento não planeja estar na sala no horário, porém pode voltar atrás e reverter o cancelamento mudando o status do agendamento da sala novamente.

## Foi Feito

- [x] -  criacão de metodo AprovarReserva tanto na controller como na service
- [x] - mudança no método JS de AddReserva para mostrar reservar em status cancelado e esconder os botoes.
- [x] - mudança no método GetProximasReservasByIdUsuarioAndDiaSemana para remover o filtro de ocultar reservas canceladas

## Como Testar
crie um planejamento e tente cancelar e aprovar segue exemplo no print

## Prints
![image](https://github.com/user-attachments/assets/9ef42b20-c90a-4bee-a722-ca0cfcfe4723)

![image](https://github.com/user-attachments/assets/95493f80-756f-41f0-982c-1cda45d41e29)



**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**
