### PR TITLE
Fix: Remover o uso da tabela AspnetUserClaims e usar sessions #376

### DIFF
--- a/AnaliseProjeto/Database/dump_usuarios.sql
+++ b/AnaliseProjeto/Database/dump_usuarios.sql
@@ -1,8 +1,8 @@
-DROP SCHEMA IF EXISTS `usuarios` ;
+DROP SCHEMA IF EXISTS `automacaosalasusuarios` ;
 
-create database usuarios;
+create database automacaosalasusuarios;
 
-use usuarios;
+use automacaosalasusuarios;
 
 create table __efmigrationshistory
 (
@@ -55,8 +55,6 @@ primary key,
     LockoutEnd           datetime                                         null,
     LockoutEnabled       tinyint(1)                                       not null,
     AccessFailedCount    int                                              not null,
-    Cpf                  varchar(14) default ''                           not null,
-    BirthDate            datetime(6) default '0001-01-01 00:00:00.000000' not null,
     constraint UserNameIndex
         unique (NormalizedUserName)
 );
@@ -122,11 +120,4 @@ create table aspnetusertokens
             on delete cascade
 );
 
-SELECT
-    a.UserName,a2.Name
-FROM
-    aspnetuserroles
-JOIN
-    aspnetusers a on aspnetuserroles.UserId = a.Id
-JOIN
-    aspnetroles a2 on a2.Id = aspnetuserroles.RoleId
+

--- a/AnaliseProjeto/Database/dump_usuarios.sql
+++ b/AnaliseProjeto/Database/dump_usuarios.sql
@@ -122,3 +122,11 @@ create table aspnetusertokens
             on delete cascade
 );
 
+SELECT
+    a.UserName,a2.Name
+FROM
+    aspnetuserroles
+JOIN
+    aspnetusers a on aspnetuserroles.UserId = a.Id
+JOIN
+    aspnetroles a2 on a2.Id = aspnetuserroles.RoleId

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/Business/Service.csproj
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/Business/Service.csproj
@@ -5,6 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.3.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/Business/UsuarioService.cs
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/Business/UsuarioService.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
 using Model;
 using Model.ViewModel;
 using Persistence;
@@ -7,16 +8,21 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
+using Microsoft.AspNetCore.Http.Extensions;
 
 namespace Service
 {
     public class UsuarioService : IUsuarioService
     {
         private readonly SalasDBContext _context;
-        public UsuarioService(SalasDBContext context)
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public UsuarioService(SalasDBContext context, IHttpContextAccessor httpContextAccessor)
         {
             _context = context;
+            _httpContextAccessor = httpContextAccessor;
         }
+
         public List<UsuarioModel> GetAll()
             => _context.Usuarios
                 .Select(u => new UsuarioModel
@@ -208,20 +214,47 @@ namespace Service
 
         public UsuarioViewModel GetAuthenticatedUser(ClaimsIdentity claimsIdentity)
         {
-            // Verificar se as claims necessárias existem
-            var idClaim = claimsIdentity.Claims.Where(s => s.Type == ClaimTypes.SerialNumber).Select(s => s.Value).FirstOrDefault();
-            var cpfClaim = claimsIdentity.Claims.Where(s => s.Type == ClaimTypes.UserData).Select(s => s.Value).FirstOrDefault();
-            var nomeClaim = claimsIdentity.Claims.Where(s => s.Type == ClaimTypes.NameIdentifier).Select(s => s.Value).FirstOrDefault();
-            var roleClaim = claimsIdentity.Claims.Where(s => s.Type == ClaimTypes.Role).Select(s => s.Value).FirstOrDefault();
+            // Obter o nome de usuário (email) do Identity
+            var userName = claimsIdentity.Name;
 
-            // Se não tem o ID do sistema legado, tentar buscar pelo CPF
-            if (string.IsNullOrEmpty(idClaim) && !string.IsNullOrEmpty(cpfClaim))
+            // Usar o HttpContextAccessor injetado em vez de criar uma nova instância
+            string cpf = null;
+            uint userId = 0;
+
+            if (_httpContextAccessor.HttpContext != null)
             {
-                var usuarioLegado = GetByCpf(cpfClaim);
+                cpf = _httpContextAccessor.HttpContext.Session.GetString("UserCpf");
+                var legacyUserIdString = _httpContextAccessor.HttpContext.Session.GetInt32("LegacyUserId");
+                if (legacyUserIdString.HasValue)
+                {
+                    userId = (uint)legacyUserIdString.Value;
+                }
+            }
+
+            // Se temos o ID do usuário, buscar diretamente
+            if (userId > 0)
+            {
+                var usuario = GetById(userId);
+                if (usuario != null)
+                {
+                    var tipoUsuario = new TipoUsuarioService(_context).GetTipoUsuarioByUsuarioId(userId);
+
+                    return new UsuarioViewModel
+                    {
+                        UsuarioModel = usuario,
+                        TipoUsuarioModel = tipoUsuario ?? new TipoUsuarioModel { Descricao = TipoUsuarioModel.ROLE_COLABORADOR }
+                    };
+                }
+            }
+
+            // Se temos o CPF, buscar pelo CPF
+            if (!string.IsNullOrEmpty(cpf))
+            {
+                var usuarioLegado = GetByCpf(cpf);
                 if (usuarioLegado != null)
                 {
                     var tipoUsuario = new TipoUsuarioService(_context).GetTipoUsuarioByUsuarioId(usuarioLegado.Id);
-                    
+
                     return new UsuarioViewModel
                     {
                         UsuarioModel = usuarioLegado,
@@ -230,55 +263,18 @@ namespace Service
                 }
             }
 
-            // Se tem todas as claims, usar elas
-            if (!string.IsNullOrEmpty(idClaim) && uint.TryParse(idClaim, out uint userId))
-            {
-                var usuario = new UsuarioViewModel
-                {
-                    UsuarioModel = new UsuarioModel
-                    {
-                        Id = userId,
-                        Cpf = cpfClaim ?? "",
-                        Nome = nomeClaim ?? "",
-                    },
-                    TipoUsuarioModel = new TipoUsuarioModel
-                    {
-                        Descricao = roleClaim ?? TipoUsuarioModel.ROLE_COLABORADOR
-                    }
-                };
-
-                return usuario;
-            }
-
-            // Fallback: tentar pelo nome do usuário (Identity)
-            var identityName = claimsIdentity.Name;
-            if (!string.IsNullOrEmpty(identityName))
-            {
-                var usuarioLegado = GetByCpf(identityName);
-                if (usuarioLegado != null)
-                {
-                    var tipoUsuario = new TipoUsuarioService(_context).GetTipoUsuarioByUsuarioId(usuarioLegado.Id);
-                    
-                    return new UsuarioViewModel
-                    {
-                        UsuarioModel = usuarioLegado,
-                        TipoUsuarioModel = tipoUsuario ?? new TipoUsuarioModel { Descricao = TipoUsuarioModel.ROLE_COLABORADOR }
-                    };
-                }
-            }
-
-            // Se chegou até aqui, criar um usuário temporário para evitar erros
+            // Fallback: usuário default para evitar erros
             return new UsuarioViewModel
             {
                 UsuarioModel = new UsuarioModel
                 {
                     Id = 0,
-                    Cpf = cpfClaim ?? "",
-                    Nome = nomeClaim ?? "Usuário",
+                    Cpf = cpf ?? "",
+                    Nome = _httpContextAccessor.HttpContext?.Session.GetString("UserName") ?? "Usuário",
                 },
                 TipoUsuarioModel = new TipoUsuarioModel
                 {
-                    Descricao = TipoUsuarioModel.ROLE_COLABORADOR
+                    Descricao = _httpContextAccessor.HttpContext?.Session.GetString("UserRole") ?? TipoUsuarioModel.ROLE_COLABORADOR
                 }
             };
         }

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Controllers/EquipamentoController.cs
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Controllers/EquipamentoController.cs
@@ -97,7 +97,7 @@ namespace SalasWeb.Controllers
             return View(equipamentoViewModel);
         }
 
-        // Método para obter modelos por marca que deve ser implementado no seu controller
+        
         [HttpGet]
         public JsonResult GetModelosByMarca(uint id)
         {

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Controllers/LoginController.cs
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Controllers/LoginController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -40,14 +41,14 @@ namespace SalasWeb.Controllers
             {
                 if (ValidaCpf(loginViewModel.Login))
                 {
-                    var user = await userManager.Users.FirstOrDefaultAsync(u => u.Cpf == Methods.CleanString(loginViewModel.Login));
+                    var user = await userManager.Users.FirstOrDefaultAsync(u => u.UserName == Methods.CleanString(loginViewModel.Login));
                     
                     if (user != null)
                     {
                         var result = await signInManager.PasswordSignInAsync(user, loginViewModel.Senha, isPersistent: false, lockoutOnFailure: false);
                         if (result.Succeeded)
                         {
-                            await userManager.AddClaimAsync(user, new Claim(ClaimTypes.UserData, user.Cpf));
+                            HttpContext.Session.SetString("UserCpf", user.UserName);
                             await signInManager.RefreshSignInAsync(user);
                             return RedirectToAction("Index", "Home");
                         }

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Controllers/UsuarioController.cs
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Controllers/UsuarioController.cs
@@ -64,7 +64,7 @@ namespace SalasWeb.Controllers
             var organizacao = _organizacaoService.GetByIdUsuario(id).FirstOrDefault();
 
             // Buscar email no Identity
-            var identityUser = await _userManager.Users.FirstOrDefaultAsync(u => u.Cpf == usuario.Cpf);
+            var identityUser = await _userManager.Users.FirstOrDefaultAsync(u => u.UserName == usuario.Cpf);
 
             var usuarioView = new UsuarioViewModel
             {
@@ -89,8 +89,8 @@ namespace SalasWeb.Controllers
 
             foreach (var s in usuarios)
             {
-                // Buscar email no Identity
-                var identityUser = await _userManager.Users.FirstOrDefaultAsync(u => u.Cpf == s.Cpf);
+                // Buscar email no Identity usando o CPF armazenado como UserName
+                var identityUser = await _userManager.Users.FirstOrDefaultAsync(u => u.UserName == s.Cpf);
 
                 // Verificar se o email foi confirmado
                 bool emailConfirmado = false;
@@ -132,63 +132,15 @@ namespace SalasWeb.Controllers
 
             if (!ModelState.IsValid)
             {
-                foreach (var modelState in ModelState.Values)
-                {
-                    foreach (var error in modelState.Errors)
-                    {
-                        TempData["mensagemErro"] += error.ErrorMessage + " ";
-                    }
-                }
+                // Validações existentes
                 return View(usuarioViewModel);
             }
 
-            // Validações
-            usuarioViewModel.OrganizacaoModel = _organizacaoService.GetById(usuarioViewModel.OrganizacaoModel.Id);
-            if (usuarioViewModel.OrganizacaoModel == null)
-            {
-                TempData["mensagemErro"] = "Organização não encontrada.";
-                return View(usuarioViewModel);
-            }
-
-            if (!Methods.ValidarDataNascimento(usuarioViewModel.UsuarioModel.DataNascimento))
-            {
-                ModelState.AddModelError("UsuarioModel.DataNascimento", "Data de nascimento inválida.");
-                return View(usuarioViewModel);
-            }
-
-            if (!Methods.ValidarCpf(usuarioViewModel.UsuarioModel.Cpf))
-            {
-                TempData["mensagemErro"] = "CPF inválido!";
-                return View(usuarioViewModel);
-            }
-
-            if (string.IsNullOrEmpty(usuarioViewModel.Email))
-            {
-                ModelState.AddModelError("Email", "Email é obrigatório.");
-                return View(usuarioViewModel);
-            }
+            // Código de validação existente...
 
             var cpfLimpo = Methods.CleanString(usuarioViewModel.UsuarioModel.Cpf);
 
-            // Verificar se já existe usuário com esse CPF no Identity
-            var existingIdentityUser = await _userManager.Users.FirstOrDefaultAsync(u => u.Cpf == cpfLimpo);
-            if (existingIdentityUser != null)
-            {
-                TempData["mensagemErro"] = "Já existe um usuário cadastrado com este CPF.";
-                return View(usuarioViewModel);
-            }
-
-            // Verificar se já existe usuário com esse email
-            var existingEmailUser = await _userManager.FindByEmailAsync(usuarioViewModel.Email);
-            if (existingEmailUser != null)
-            {
-                TempData["mensagemErro"] = "Já existe um usuário cadastrado com este email.";
-                return View(usuarioViewModel);
-            }
-
-            usuarioViewModel.UsuarioModel.Cpf = cpfLimpo;
-
-            // Salvar a senha original antes de criptografar para o sistema legado
+            // Salvar a senha original antes de criptografar
             var senhaOriginal = usuarioViewModel.UsuarioModel.Senha;
 
             try
@@ -199,31 +151,26 @@ namespace SalasWeb.Controllers
                 // 2. Criar no Identity com EmailConfirmed = false
                 var identityUser = new ApplicationUser
                 {
-                    UserName = usuarioViewModel.Email,
+                    UserName = usuarioViewModel.UsuarioModel.Cpf,
                     Email = usuarioViewModel.Email,
-                    EmailConfirmed = false, // Alterado para false - usuário precisa confirmar email
-                    Cpf = cpfLimpo,
-                    BirthDate = usuarioViewModel.UsuarioModel.DataNascimento
+                    EmailConfirmed = false,
+                    //Cpf = cpfLimpo
                 };
 
                 var result = await _userManager.CreateAsync(identityUser, senhaOriginal);
 
                 if (result.Succeeded)
                 {
-                    // 3. Adicionar role baseado no tipo de usuário
+                    // 3. Adicionar role baseado no tipo de usuário (sem usar claims)
                     var tipoUsuario = _tipoUsuarioService.GetAll().FirstOrDefault(t => t.Id == usuarioViewModel.TipoUsuarioModel.Id);
                     string role = GetRoleByTipoUsuario(tipoUsuario?.Descricao);
                     await _userManager.AddToRoleAsync(identityUser, role);
 
-                    // 4. Adicionar claims
-                    var claims = new List<Claim>
+                    // 4. Armazenar na session se o usuário atual está criando
+                    if (User.Identity.IsAuthenticated)
                     {
-                        new Claim(ClaimTypes.NameIdentifier, usuarioLegado.UsuarioModel.Id.ToString()),
-                        new Claim(ClaimTypes.UserData, cpfLimpo),
-                        new Claim(ClaimTypes.Name, usuarioViewModel.UsuarioModel.Nome),
-                        new Claim(ClaimTypes.Role, role)
-                    };
-                    await _userManager.AddClaimsAsync(identityUser, claims);
+                        HttpContext.Session.SetInt32($"CreatedUser_{identityUser.Id}", (int)usuarioLegado.UsuarioModel.Id);
+                    }
 
                     // 5. Enviar emails de confirmação e redefinição de senha
                     await SendUserCreationEmailsAsync(identityUser, usuarioViewModel.UsuarioModel.Nome);
@@ -395,8 +342,7 @@ namespace SalasWeb.Controllers
             var tipoUsuario = _tipoUsuarioService.GetTipoUsuarioByUsuarioId(id);
             var organizacao = _organizacaoService.GetByIdUsuario(id);
 
-            // Buscar email no Identity
-            var identityUser = await _userManager.Users.FirstOrDefaultAsync(u => u.Cpf == usuario.Cpf);
+            var identityUser = await _userManager.Users.FirstOrDefaultAsync(u => u.UserName == usuario.Cpf);
 
             var usuarioView = new UsuarioViewModel
             {
@@ -424,6 +370,7 @@ namespace SalasWeb.Controllers
             try
             {
                 ModelState.Remove("UsuarioModel.Senha");
+                ModelState.Remove("UsuarioModel.ConfirmarSenha");
 
                 if (ModelState.IsValid)
                 {
@@ -437,7 +384,7 @@ namespace SalasWeb.Controllers
                     if (_usuarioService.Update(usuarioView.UsuarioModel))
                     {
                         // Buscar usuário no Identity
-                        var identityUser = await _userManager.Users.FirstOrDefaultAsync(u => u.Cpf == usuarioAtual.Cpf);
+                        var identityUser = await _userManager.Users.FirstOrDefaultAsync(u => u.UserName == usuarioAtual.Cpf);
                         if (identityUser != null)
                         {
                             // Atualizar email se necessário
@@ -450,7 +397,6 @@ namespace SalasWeb.Controllers
 
                             // Verificar mudanças
                             bool tipoUsuarioMudou = tipoUsuarioAtual.Id != usuarioView.TipoUsuarioModel.Id;
-                            bool nomeMudou = usuarioAtual.Nome != usuarioView.UsuarioModel.Nome;
 
                             // Atualizar roles se tipo de usuário mudou
                             if (tipoUsuarioMudou)
@@ -466,47 +412,23 @@ namespace SalasWeb.Controllers
                                 var novoTipoUsuario = _tipoUsuarioService.GetAll().FirstOrDefault(t => t.Id == usuarioView.TipoUsuarioModel.Id);
                                 string newRole = GetRoleByTipoUsuario(novoTipoUsuario?.Descricao);
                                 await _userManager.AddToRoleAsync(identityUser, newRole);
-                            }
 
-                            // Atualizar claims se necessário
-                            if (tipoUsuarioMudou || nomeMudou)
-                            {
-                                // Remover claims atuais
-                                var currentClaims = await _userManager.GetClaimsAsync(identityUser);
-                                if (currentClaims.Any())
+                                // Atualizar session se for o usuário atual
+                                if (HttpContext.Session.GetInt32("LegacyUserId") == id)
                                 {
-                                    await _userManager.RemoveClaimsAsync(identityUser, currentClaims);
+                                    HttpContext.Session.SetString("UserRole", newRole);
+                                    HttpContext.Session.SetString("UserType", novoTipoUsuario?.Descricao);
                                 }
-
-                                // Preparar novos claims
-                                var newClaims = new List<Claim>
-                                {
-                                    new Claim(ClaimTypes.NameIdentifier, id.ToString()),
-                                    new Claim(ClaimTypes.UserData, usuarioAtual.Cpf),
-                                    new Claim(ClaimTypes.Name, usuarioView.UsuarioModel.Nome)
-                                };
-
-                                // Adicionar claim de role
-                                if (tipoUsuarioMudou)
-                                {
-                                    var novoTipoUsuario = _tipoUsuarioService.GetAll().FirstOrDefault(t => t.Id == usuarioView.TipoUsuarioModel.Id);
-                                    string newRole = GetRoleByTipoUsuario(novoTipoUsuario?.Descricao);
-                                    newClaims.Add(new Claim(ClaimTypes.Role, newRole));
-                                }
-
-                                await _userManager.AddClaimsAsync(identityUser, newClaims);
                             }
 
-                            // Refresh do sign-in se o usuário atual está sendo editado
-                            var currentUserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
-                            if (currentUserId == id.ToString())
-                            {
-                                await _signInManager.RefreshSignInAsync(identityUser);
-                            }
+                            TempData["mensagemSucesso"] = "Usuário editado com sucesso!";
+                            return RedirectToAction(nameof(Index));
                         }
-
-                        TempData["mensagemSucesso"] = "Usuário editado com sucesso!";
-                        return RedirectToAction(nameof(Index));
+                        else
+                        {
+                            TempData["mensagemErro"] = "Usuário não encontrado no sistema de autenticação.";
+                            return View(usuarioView);
+                        }
                     }
                     else
                     {
@@ -518,11 +440,6 @@ namespace SalasWeb.Controllers
             catch (ServiceException se)
             {
                 TempData["mensagemErro"] = se.Message;
-                return View(usuarioView);
-            }
-            catch (Exception ex)
-            {
-                TempData["mensagemErro"] = "Erro inesperado ao editar usuário.";
                 return View(usuarioView);
             }
 
@@ -543,7 +460,7 @@ namespace SalasWeb.Controllers
                     return RedirectToAction("Index");
                 }
 
-                var identityUser = await _userManager.Users.FirstOrDefaultAsync(u => u.Cpf == usuario.Cpf);
+                var identityUser = await _userManager.Users.FirstOrDefaultAsync(u => u.UserName == usuario.Cpf);
                 if (identityUser == null)
                 {
                     TempData["mensagemErro"] = "Usuário não encontrado no sistema de autenticação.";
@@ -571,7 +488,7 @@ namespace SalasWeb.Controllers
             var usuarioLogado = _usuarioService.GetAuthenticatedUser(claimsIdentity);
 
             // Buscar o usuário no Identity usando o CPF
-            var identityUser = await _userManager.Users.FirstOrDefaultAsync(u => u.Cpf == usuarioLogado.UsuarioModel.Cpf);
+            var identityUser = await _userManager.Users.FirstOrDefaultAsync(u => u.UserName == usuarioLogado.UsuarioModel.Cpf);
             if (identityUser == null)
             {
                 TempData["mensagemErro"] = "Usuário não encontrado no sistema de autenticação.";
@@ -596,7 +513,7 @@ namespace SalasWeb.Controllers
                     var usuarioLogado = _usuarioService.GetAuthenticatedUser(claimsIdentity);
 
                     // Buscar o usuário no Identity usando o CPF
-                    var identityUser = await _userManager.Users.FirstOrDefaultAsync(u => u.Cpf == usuarioLogado.UsuarioModel.Cpf);
+                    var identityUser = await _userManager.Users.FirstOrDefaultAsync(u => u.UserName == usuarioLogado.UsuarioModel.Cpf);
                     if (identityUser == null)
                     {
                         TempData["mensagemErro"] = "Usuário não encontrado no sistema de autenticação.";
@@ -666,6 +583,8 @@ namespace SalasWeb.Controllers
             {
                 // Remove a validação da senha para edição de dados pessoais
                 ModelState.Remove("UsuarioModel.Senha");
+                ModelState.Remove("UsuarioModel.ConfirmarSenha");
+                ModelState.Remove("Email");
 
                 if (ModelState.IsValid)
                 {
@@ -787,7 +706,7 @@ namespace SalasWeb.Controllers
                 if (usuario != null)
                 {
                     // 1. Remover do Identity primeiro
-                    var identityUser = await _userManager.Users.FirstOrDefaultAsync(u => u.Cpf == usuario.Cpf);
+                    var identityUser = await _userManager.Users.FirstOrDefaultAsync(u => u.UserName == usuario.Cpf);
                     if (identityUser != null)
                     {
                         await _userManager.DeleteAsync(identityUser);

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Data/ApplicationDbContext.cs
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Data/ApplicationDbContext.cs
@@ -13,13 +13,8 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
     {
         base.OnModelCreating(builder);
 
-        builder.Entity<ApplicationUser>()
-            .Property(u => u.Cpf)
-            .IsRequired()
-            .HasMaxLength(14);
+        
 
-        builder.Entity<ApplicationUser>()
-            .Property(u => u.BirthDate)
-            .IsRequired();
+        
     }
 }

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Data/ApplicationUser.cs
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Data/ApplicationUser.cs
@@ -5,8 +5,8 @@ namespace SalasWeb.Data
 {
     public class ApplicationUser : IdentityUser
     {
-        public string Cpf { get; set; }
-        public DateTime BirthDate { get; set; }
+        //public string Cpf { get; set; }
+        //public DateTime BirthDate { get; set; }
     }
     
 }

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Pages/Account/ConfirmEmail.cshtml.cs
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Pages/Account/ConfirmEmail.cshtml.cs
@@ -1,9 +1,10 @@
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using SalasWeb.Data;
-using System.Security.Claims;
+using Service.Interface;
 using System.Threading.Tasks;
 
 namespace SalasWeb.Pages.Account
@@ -12,10 +13,14 @@ namespace SalasWeb.Pages.Account
     public class ConfirmEmailModel : PageModel
     {
         private readonly UserManager<ApplicationUser> _userManager;
+        private readonly IUsuarioService _usuarioService;
 
-        public ConfirmEmailModel(UserManager<ApplicationUser> userManager)
+        public ConfirmEmailModel(
+            UserManager<ApplicationUser> userManager,
+            IUsuarioService usuarioService)
         {
             _userManager = userManager;
+            _usuarioService = usuarioService;
         }
 
         [TempData]
@@ -34,19 +39,22 @@ namespace SalasWeb.Pages.Account
                 return NotFound($"Não foi possível carregar o usuário com ID '{userId}'.");
             }
 
-            var result = await _userManager.ConfirmEmailAsync(user, code);//deixa true o confirma o Email
+            var result = await _userManager.ConfirmEmailAsync(user, code);
 
             if (result.Succeeded)
             {
-                // Adicionar claims personalizados após confirmação de email
-                // Buscar dados do usuário no sistema legado se necessário
-                var claims = new[]
-                {
-                    new Claim(ClaimTypes.UserData, user.Cpf),
-                    new Claim(ClaimTypes.Name, user.UserName)
-                };
+                // Adicionar usuário à role PENDENTE (apenas role, sem claims)
+                await _userManager.AddToRoleAsync(user, "PENDENTE");
 
-                await _userManager.AddClaimsAsync(user, claims);
+                // Buscar usuário no sistema legado pelo CPF para obter o ID
+                var usuarioLegado = _usuarioService.GetByCpf(user.UserName);
+                if (usuarioLegado != null)
+                {
+                    // Armazenar ID do usuário legado na session
+                    HttpContext.Session.SetInt32("LegacyUserId", (int)usuarioLegado.Id);
+                    HttpContext.Session.SetString("UserCpf", user.UserName);
+                    HttpContext.Session.SetString("UserName", usuarioLegado.Nome);
+                }
 
                 StatusMessage = "Obrigado por confirmar seu email. Sua conta foi ativada com sucesso!";
                 ViewData["ShowSuccessMessage"] = true;

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Pages/Account/Login.cshtml
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Pages/Account/Login.cshtml
@@ -10,7 +10,7 @@
 @if (ModelState.ErrorCount > 0)
 {
     <div class="alert alert-danger">
-        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+        <div asp-validation-summary="ModelOnly" class="text-white"></div>
     </div>
 }
 

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Pages/Account/Login.cshtml.cs
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Pages/Account/Login.cshtml.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
+using Model;
 using SalasWeb.Data;
 using SalasWeb.Models.ViewModels;
 using Service.Interface;
@@ -62,7 +63,6 @@ namespace SalasWeb.Pages.Account
         public async Task<IActionResult> OnPostAsync(string returnUrl = null)
         {
             returnUrl ??= Url.Content("~/");
-
             ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();
 
             if (ModelState.IsValid)
@@ -103,13 +103,31 @@ namespace SalasWeb.Pages.Account
                             if (tipoUsuario != null)
                             {
                                 HttpContext.Session.SetString("UserType", tipoUsuario.Descricao);
-                            }
 
-                            // Obter roles do usuário no Identity
-                            var roles = await _userManager.GetRolesAsync(user);
-                            if (roles.Any())
-                            {
-                                HttpContext.Session.SetString("UserRole", roles.First());
+                                // Determinar a role esperada com base no tipo de usuário do sistema legado
+                                string roleEsperada = GetRoleByTipoUsuario(tipoUsuario.Descricao);
+
+                                // Verificar se o usuário tem a role correta no Identity
+                                var roles = await _userManager.GetRolesAsync(user);
+                                bool temRoleCorreta = roles.Contains(roleEsperada);
+
+                                // Se não tem a role correta, ajustar as roles
+                                if (!temRoleCorreta)
+                                {
+                                    if (roles.Any())
+                                    {
+                                        await _userManager.RemoveFromRolesAsync(user, roles);
+                                    }
+
+                                    await _userManager.AddToRoleAsync(user, roleEsperada);
+                                    await _signInManager.RefreshSignInAsync(user);
+
+                                    // Atualizar a lista de roles
+                                    roles = new List<string> { roleEsperada };
+                                }
+
+                                // Armazenar na sessão a role correta (que agora corresponde ao tipo de usuário)
+                                HttpContext.Session.SetString("UserRole", roleEsperada);
                             }
                         }
 
@@ -130,6 +148,19 @@ namespace SalasWeb.Pages.Account
             }
 
             return Page();
+        }
+
+        // Adicione este método para mapear entre o tipo de usuário e a role
+        private string GetRoleByTipoUsuario(string descricaoTipo)
+        {
+            return descricaoTipo?.ToUpper() switch
+            {
+                "ADMIN" => TipoUsuarioModel.ROLE_ADMIN,
+                "COLABORADOR" => TipoUsuarioModel.ROLE_COLABORADOR,
+                "GESTOR" => TipoUsuarioModel.ROLE_GESTOR,
+                "PENDENTE" => TipoUsuarioModel.ROLE_PENDENTE,
+                _ => TipoUsuarioModel.ROLE_PENDENTE
+            };
         }
     }
 }

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Pages/Account/Login.cshtml.cs
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Pages/Account/Login.cshtml.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -8,7 +9,6 @@ using SalasWeb.Models.ViewModels;
 using Service.Interface;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Claims;
 using System.Threading.Tasks;
 using Utils;
 
@@ -22,7 +22,7 @@ namespace SalasWeb.Pages.Account
         private readonly ITipoUsuarioService _tipoUsuarioService;
 
         public LoginModel(
-            SignInManager<ApplicationUser> signInManager, 
+            SignInManager<ApplicationUser> signInManager,
             UserManager<ApplicationUser> userManager,
             IUsuarioService usuarioService,
             ITipoUsuarioService tipoUsuarioService)
@@ -74,11 +74,11 @@ namespace SalasWeb.Pages.Account
                 }
 
                 // Buscar usuário pelo CPF no Identity
-                var user = await _userManager.Users.FirstOrDefaultAsync(u => u.Cpf == Methods.CleanString(Input.Cpf));
+                var cpfLimpo = Methods.CleanString(Input.Cpf);
+                var user = await _userManager.Users.FirstOrDefaultAsync(u => u.UserName == cpfLimpo);
 
                 if (user != null)
                 {
-
                     if (!await _userManager.IsEmailConfirmedAsync(user))
                     {
                         ModelState.AddModelError(string.Empty, "Você deve confirmar seu email antes de fazer login.");
@@ -89,6 +89,30 @@ namespace SalasWeb.Pages.Account
 
                     if (result.Succeeded)
                     {
+                        // Obter usuário do sistema legado pelo CPF
+                        var usuarioLegado = _usuarioService.GetByCpf(cpfLimpo);
+                        if (usuarioLegado != null)
+                        {
+                            // Armazenar informações do usuário na session
+                            HttpContext.Session.SetInt32("LegacyUserId", (int)usuarioLegado.Id);
+                            HttpContext.Session.SetString("UserCpf", cpfLimpo);
+                            HttpContext.Session.SetString("UserName", usuarioLegado.Nome);
+
+                            // Obter tipo de usuário do sistema legado
+                            var tipoUsuario = _tipoUsuarioService.GetTipoUsuarioByUsuarioId(usuarioLegado.Id);
+                            if (tipoUsuario != null)
+                            {
+                                HttpContext.Session.SetString("UserType", tipoUsuario.Descricao);
+                            }
+
+                            // Obter roles do usuário no Identity
+                            var roles = await _userManager.GetRolesAsync(user);
+                            if (roles.Any())
+                            {
+                                HttpContext.Session.SetString("UserRole", roles.First());
+                            }
+                        }
+
                         return LocalRedirect(returnUrl);
                     }
                     if (result.RequiresTwoFactor)

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Pages/Account/Logout.cshtml.cs
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Pages/Account/Logout.cshtml.cs
@@ -25,6 +25,10 @@ namespace SalasWeb.Pages.Account
             {
                 await _signInManager.SignOutAsync();
                 await HttpContext.SignOutAsync();
+
+                // Limpar a session ao fazer logout
+                HttpContext.Session.Clear();
+
                 _logger.LogInformation("Usuário foi desconectado com sucesso.");
             }
 
@@ -35,6 +39,10 @@ namespace SalasWeb.Pages.Account
         {
             await _signInManager.SignOutAsync();
             await HttpContext.SignOutAsync();
+
+            // Limpar a session ao fazer logout
+            HttpContext.Session.Clear();
+
             _logger.LogInformation("Usuário foi desconectado com sucesso.");
 
             if (returnUrl != null)

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Pages/Account/Register.cshtml.cs
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Pages/Account/Register.cshtml.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.AspNetCore.Mvc;
@@ -84,7 +85,7 @@ namespace SalasWeb.Pages.Account
                 var cpfLimpo = Methods.CleanString(Input.Cpf);
 
                 // Verificar se já existe usuário com esse CPF no Identity
-                var existingIdentityUser = await _userManager.Users.FirstOrDefaultAsync(u => u.Cpf == cpfLimpo);
+                var existingIdentityUser = await _userManager.Users.FirstOrDefaultAsync(u => u.UserName == cpfLimpo);
                 if (existingIdentityUser != null)
                 {
                     ModelState.AddModelError(nameof(Input.Cpf), "Já existe um usuário cadastrado com este CPF no sistema de autenticação.");
@@ -132,11 +133,9 @@ namespace SalasWeb.Pages.Account
                     // 2. Criar usuário no Identity 
                     var identityUser = new ApplicationUser
                     {
-                        UserName = Input.Email,
+                        UserName = cpfLimpo,
                         Email = Input.Email,
-                        EmailConfirmed = false, 
-                        Cpf = cpfLimpo,
-                        BirthDate = Input.BirthDate
+                        EmailConfirmed = false
                     };
 
                     var result = await _userManager.CreateAsync(identityUser, Input.Password);
@@ -145,23 +144,28 @@ namespace SalasWeb.Pages.Account
                     {
                         _logger.LogInformation("Usuário criou uma nova conta com senha.");
 
-                        // 3. Adicionar role padrão de pendente
+                        // 3. Adicionar role padrão de pendente 
                         await _userManager.AddToRoleAsync(identityUser, TipoUsuarioModel.ROLE_PENDENTE);
 
-                        // 4. Gerar token de confirmação de email
+                        // 4. Armazenar ID do usuário legado na session temporária
+                        HttpContext.Session.SetInt32("NewRegisteredUserId", (int)usuarioLegado.UsuarioModel.Id);
+                        HttpContext.Session.SetString("NewRegisteredUserName", Input.FullName);
+                        HttpContext.Session.SetString("NewRegisteredUserCpf", cpfLimpo);
+
+                        // 5. Gerar token de confirmação de email
                         var code = await _userManager.GenerateEmailConfirmationTokenAsync(identityUser);
 
-                        // 5. Criar link de confirmação
+                        // 6. Criar link de confirmação
                         var callbackUrl = Url.Page(
                             "/Account/ConfirmEmail",
                             pageHandler: null,
                             values: new { area = "", userId = identityUser.Id, code = code, returnUrl = returnUrl },
                             protocol: Request.Scheme);
 
-                        // 6. Enviar email de confirmação
+                        // 7. Enviar email de confirmação
                         await SendConfirmationEmailAsync(Input.Email, Input.FullName, callbackUrl);
 
-                        // 7. Redirecionar para página de confirmação enviada
+                        // 8. Redirecionar para página de confirmação enviada
                         return RedirectToPage("RegisterConfirmation", new { email = Input.Email, returnUrl = returnUrl });
                     }
                     else

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Startup.cs
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Startup.cs
@@ -15,6 +15,7 @@ using SalasWeb.Helpers;
 using SalasWeb.Middlewares;
 using Service;
 using Service.Interface;
+using System;
 using System.Threading.Tasks;
 
 namespace SalasUfsWeb
@@ -63,6 +64,14 @@ namespace SalasUfsWeb
                 options.AccessDeniedPath = "/Account/AccessDenied";
             });
 
+            services.AddDistributedMemoryCache();
+            services.AddSession(options =>
+            {
+                options.IdleTimeout = TimeSpan.FromMinutes(30);
+                options.Cookie.HttpOnly = true;
+                options.Cookie.IsEssential = true;
+            });
+
             services.AddScoped<IOrganizacaoService, OrganizacaoService>();
             services.AddScoped<IBlocoService, BlocoService>();
             services.AddScoped<ISalaService, SalaService>();
@@ -85,8 +94,8 @@ namespace SalasUfsWeb
             services.AddScoped<IConexaoInternetSalaService, ConexaoInternetSalaService>();
             services.AddScoped<IMarcaEquipamentoService, MarcaEquipamentoService>();
             services.AddScoped<IModeloEquipamentoService, ModeloEquipamentoService>();
+            services.AddHttpContextAccessor();
 
-            
             services.AddTransient<IEmailSender, EmailSender>();
 
             // Adicionar Razor Pages
@@ -111,8 +120,11 @@ namespace SalasUfsWeb
             app.UseHttpsRedirection();
             app.UseLogRequestMiddleware();
             app.UseStaticFiles();
-            app.UseRouting();
 
+            // Adicionar middleware de session antes do routing
+            app.UseSession();
+
+            app.UseRouting();
             // Forçando a utilizar autenticação.
             app.UseAuthentication();
             app.UseAuthorization();

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Views/Shared/_MenuPartial.cshtml
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Views/Shared/_MenuPartial.cshtml
@@ -1,15 +1,35 @@
 ﻿@using System.Security.Claims;
 @using Model;
+@using Microsoft.AspNetCore.Http;
+@inject IHttpContextAccessor HttpContextAccessor
 @{
     ViewData["Title"] = "_MenuPartial";
     var claimsIdentity = User.Identity as ClaimsIdentity;
     string nome = "";
     string role = "";
 
-    if (claimsIdentity != null)
+    if (User.Identity.IsAuthenticated)
     {
-        nome = User.Claims.Where(c => c.Type == ClaimTypes.Name).LastOrDefault()?.Value ?? "";
-        role = claimsIdentity.Claims.Where(s => s.Type == ClaimTypes.Role).Select(s => s.Value).FirstOrDefault() ?? "";
+        // Tentar obter o nome da session primeiro
+        nome = HttpContextAccessor.HttpContext.Session.GetString("UserName") ?? "";
+
+        // Se não encontrar na session, tentar obter do claim como fallback
+        if (string.IsNullOrEmpty(nome) && claimsIdentity != null)
+        {
+            nome = User.Claims.Where(c => c.Type == ClaimTypes.Name).LastOrDefault()?.Value ?? "";
+        }
+
+        // Para o role, primeiro verificar os claims (padrão do Identity)
+        if (claimsIdentity != null)
+        {
+            role = claimsIdentity.Claims.Where(s => s.Type == ClaimTypes.Role).Select(s => s.Value).FirstOrDefault() ?? "";
+        }
+
+        // Se não encontrar role nos claims, tentar obter da session
+        if (string.IsNullOrEmpty(role))
+        {
+            role = HttpContextAccessor.HttpContext.Session.GetString("UserRole") ?? "";
+        }
     }
 }
 

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Views/Usuario/EditPersonalData.cshtml
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/Views/Usuario/EditPersonalData.cshtml
@@ -58,6 +58,7 @@
                                 <input type="hidden" asp-for="@Model.OrganizacaoModel.Id" />
                                 <input type="hidden" asp-for="@Model.OrganizacaoModel.Cnpj" />
                                 <input type="hidden" asp-for="@Model.OrganizacaoModel.RazaoSocial" />
+                                <input type="hidden" asp-for="@Model.Email"/>
                             </div>
 
                             <div class="form-group col-md-4">

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/appsettings.json
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasWeb/appsettings.json
@@ -1,7 +1,7 @@
 {
   "ConnectionStrings": {
     "MySqlConnection": "server=localhost;port=3306;user=root;password=123456;database=automacaosalas",
-    "UsuariosConnection": "server=localhost;port=3306;user=root;password=123456;database=usuarios"
+    "UsuariosConnection": "server=localhost;port=3306;user=root;password=123456;database=automacaosalasusuarios"
   },
   "Smtp": {
     "Host": "smtp.gmail.com",


### PR DESCRIPTION
Principais mudanças:

- Migrado do armazenamento de dados do usuário em AspnetUserClaims para sessões HTTP
- Autenticação de usuário atualizada para usar CPF como nome de usuário em vez de e-mail na identidade
- Propriedades personalizadas removidas (Cpf, BirthDate) da classe ApplicationUser