### PR TITLE
Fix: Resolve o retorno do GET de monitoramento da API. Resolve #379

### DIFF
--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/Business/MonitoramentoService.cs
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/Business/MonitoramentoService.cs
@@ -48,11 +48,20 @@ namespace Service
 
         public MonitoramentoModel GetByIdSalaAndTipoEquipamento(uint idSala, string tipoEquipamento)
         {
+            if (string.IsNullOrWhiteSpace(tipoEquipamento))
+                return null;
+
+            var tipoEquipamentoNormalizado = tipoEquipamento.Trim();
             var moni = _context.Monitoramentos.ToList();
             var equip = _context.Equipamentos.ToList();
             var monitoramentos = (from m in moni
                                   join e in equip on m.IdEquipamento equals e.Id
-                                  where e.IdSala == idSala && tipoEquipamento.ToUpper().Equals(e.TipoEquipamento.Trim().ToUpper())
+                                  where e.IdSala == idSala &&
+                                        !string.IsNullOrWhiteSpace(e.TipoEquipamento) &&
+                                        string.Equals(
+                                            tipoEquipamentoNormalizado,
+                                            e.TipoEquipamento.Trim(),
+                                            StringComparison.OrdinalIgnoreCase)
                                   select new MonitoramentoModel
                                   {
                                       Id = m.Id,
@@ -68,11 +77,20 @@ namespace Service
 
         public MonitoramentoModel GetByIdSalaAndTipoEquipamento(uint idSala, string tipoEquipamento, uint idUsuario)
         {
+            if (string.IsNullOrWhiteSpace(tipoEquipamento))
+                return null;
+
+            var tipoEquipamentoNormalizado = tipoEquipamento.Trim();
             var moni = _context.Monitoramentos.ToList();
             var equip = _context.Equipamentos.ToList();
             var monitoramentos = (from m in moni
                                   join e in equip on m.IdEquipamento equals e.Id
-                                  where e.IdSala == idSala && tipoEquipamento.ToUpper().Equals(e.TipoEquipamento.Trim().ToUpper())
+                                  where e.IdSala == idSala &&
+                                        !string.IsNullOrWhiteSpace(e.TipoEquipamento) &&
+                                        string.Equals(
+                                            tipoEquipamentoNormalizado,
+                                            e.TipoEquipamento.Trim(),
+                                            StringComparison.OrdinalIgnoreCase)
                                   select new MonitoramentoModel
                                   {
                                       Id = m.Id,

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasAPI/Controllers/MonitoramentoController.cs
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasAPI/Controllers/MonitoramentoController.cs
@@ -109,6 +109,14 @@ namespace SalasAPI.Controllers
         {
             try
             {
+                if (string.IsNullOrWhiteSpace(tipoEquipamento))
+                    return BadRequest(new
+                    {
+                        result = "null",
+                        httpCode = (int)HttpStatusCode.BadRequest,
+                        message = "O parâmetro tipoEquipamento é obrigatório."
+                    });
+
                 var monitoramento = _monitoramentoService.GetByIdSalaAndTipoEquipamento(idSala, tipoEquipamento);
 
                 if (monitoramento == null)
@@ -133,6 +141,15 @@ namespace SalasAPI.Controllers
                     result = "null",
                     httpCode = (int)HttpStatusCode.InternalServerError,
                     message = e.Message
+                });
+            }
+            catch (Exception)
+            {
+                return StatusCode((int)HttpStatusCode.InternalServerError, new
+                {
+                    result = "null",
+                    httpCode = (int)HttpStatusCode.InternalServerError,
+                    message = "Ocorreu um erro inesperado ao obter o monitoramento."
                 });
             }
 

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasAPI/Controllers/MonitoramentoController.cs
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasAPI/Controllers/MonitoramentoController.cs
@@ -4,6 +4,7 @@ using Model;
 using Model.ViewModel;
 using Service;
 using Service.Interface;
+using System;
 using System.Net;
 using System.Security.Claims;
 

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasAPI/Startup.cs
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/SalasAPI/Startup.cs
@@ -85,6 +85,15 @@ namespace WebAPI
                 });
             });
 
+            services.AddDistributedMemoryCache();
+            services.AddSession(options =>
+            {
+                options.IdleTimeout = TimeSpan.FromMinutes(30);
+                options.Cookie.HttpOnly = true;
+                options.Cookie.IsEssential = true;
+            });
+            services.AddHttpContextAccessor();
+
             // Injections
             services.AddAuthorization();
             services.AddScoped<IOrganizacaoService, OrganizacaoService>();
@@ -143,6 +152,7 @@ namespace WebAPI
             app.UseCors(builder => builder.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader());
 
             app.UseHttpsRedirection();
+            app.UseSession();
 
             app.UseWhen(context => CheckRoutesHardware(context), appBuilder =>
              {

--- a/Codigo/ModuloDeSoftware/AutomacaoSalas/ServiceTests/MonitoramentoServiceTests.cs
+++ b/Codigo/ModuloDeSoftware/AutomacaoSalas/ServiceTests/MonitoramentoServiceTests.cs
@@ -1,0 +1,90 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Persistence;
+using Service;
+using System;
+using System.Collections.Generic;
+
+namespace Service.Tests
+{
+    [TestClass()]
+    public class MonitoramentoServiceTests
+    {
+        private SalasDBContext? context;
+        private MonitoramentoService? monitoramentoService;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            var builder = new DbContextOptionsBuilder<SalasDBContext>();
+            builder.UseInMemoryDatabase($"automacaosalas-monitoramento-{Guid.NewGuid()}")
+                   .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning));
+
+            context = new SalasDBContext(builder.Options);
+            context.Database.EnsureCreated();
+
+            context.Equipamentos.AddRange(new List<Equipamento>
+            {
+                new()
+                {
+                    Id = 1,
+                    IdSala = 10,
+                    TipoEquipamento = "LUZES",
+                    Status = "D"
+                },
+                new()
+                {
+                    Id = 2,
+                    IdSala = 10,
+                    TipoEquipamento = null!,
+                    Status = "D"
+                }
+            });
+
+            context.Monitoramentos.AddRange(new List<Monitoramento>
+            {
+                new()
+                {
+                    Id = 1,
+                    IdEquipamento = 1,
+                    IdOperacao = 1,
+                    IdUsuario = 1,
+                    DataHora = DateTime.Now,
+                    Estado = 1
+                },
+                new()
+                {
+                    Id = 2,
+                    IdEquipamento = 2,
+                    IdOperacao = 1,
+                    IdUsuario = 1,
+                    DataHora = DateTime.Now,
+                    Estado = 0
+                }
+            });
+
+            context.SaveChanges();
+            monitoramentoService = new MonitoramentoService(context);
+        }
+
+        [TestMethod()]
+        public void GetByIdSalaAndTipoEquipamentoTest_DeveIgnorarTipoNuloNoBanco()
+        {
+            var monitoramento = monitoramentoService!.GetByIdSalaAndTipoEquipamento(10, " luzes ");
+
+            Assert.IsNotNull(monitoramento);
+            Assert.AreEqual(1, monitoramento.Id);
+            Assert.AreEqual(1, monitoramento.IdEquipamento);
+            Assert.IsTrue(monitoramento.Estado);
+        }
+
+        [TestMethod()]
+        public void GetByIdSalaAndTipoEquipamentoTest_DeveRetornarNullQuandoTipoForInvalido()
+        {
+            var monitoramento = monitoramentoService!.GetByIdSalaAndTipoEquipamento(10, " ");
+
+            Assert.IsNull(monitoramento);
+        }
+    }
+}


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/user-attachments/assets/04a51bd6-7788-4f06-a24b-9c8ebc5154e6" width="10%">
  <h2>Pull Request</h2> 
</div>


## Foi Solicitado
Investigar e resolver o problema de retorno do metodo GET de monitoramento e com isso foi encontrado que o problema era uma falta de injeção de dependencia que foi resolvida e o método voltou a funcionar

## Foi Feito
[Explique as alterações realizadas neste Pull Request de forma detalhada. Use o checklist markdown como o exemplo abaixo]
- [x] Inicialmente foi adicionado validações e verificações(Uso do IsNullOrWhiteSpace, deixando de usar o ToUpper) pra investigar o motivo do erro 500 e adicionado um tratamento de exceção mais elaborado pra investigar o motivo do erro
- [x] UsuarioService passou a pedir IHttpContextAccessor no construtor e o container não sabia criar isso;
- [x] services.AddDistributedMemoryCache(); e services.AddSession(...) 0 -> Porque o UsuarioService não usa só o contexto HTTP; ele também lê valores da sessão.
- [x] app.UseSession() -> Porque registrar a sessão no container não basta; o middleware precisa estar ativo no pipeline para HttpContext.Session funcionar.
